### PR TITLE
Enable configuration via settings

### DIFF
--- a/CacherExtension.py
+++ b/CacherExtension.py
@@ -1,7 +1,6 @@
 import logging
 import requests
 import time
-import os
 
 from ulauncher.api.client.Extension import Extension
 from ulauncher.api.client.EventListener import EventListener
@@ -12,9 +11,6 @@ from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAct
 from ulauncher.api.shared.action.OpenUrlAction import OpenUrlAction
 logging.basicConfig()
 logger = logging.getLogger(__name__)
-
-ext_path = os.path.dirname(os.path.abspath(__file__))
-
 
 class KeywordQueryEventListener(EventListener):
     def on_event(self, event, extension):

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Find and copy to the clipboard your cacher snippets through the Ulauncher.
 2. Fill in corresponding configurations in Ulauncher extensions settings.
 
 ### Requirements
-Python 2.7.9+
-python-requests (`pip install requests`)
+- Python 2.7.9+
+- python-requests (`pip install requests`)

--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ Find and copy to the clipboard your cacher snippets through the Ulauncher.
 
 ## How to make it work.
 
-1) Take your cacher credentials:
+1. Get your API key and token from cacher:
 
 ![cacher credentials](https://github.com/CacherApp/alfred-cacher/blob/master/media/get-key-token.gif)
 
-2) Fill in corresponding configurations at: `~/.cache/ulauncher_cache/extensions/com.github.nortmas.cacher/config.ini`
+2. Fill in corresponding configurations in Ulauncher extensions settings.
 
-3) Restart Ulauncher.
-
-### Requirements 
+### Requirements
 Python 2.7.9+
+python-requests (`pip install requests`)

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,0 @@
-[General]
-key=
-token=

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": "1",
+  "manifest_version": "2",
   "api_version": "1",
   "name": "Cacher",
   "description": "Search in cacher snippets",

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,18 @@
       "name": "Cacher",
       "description": "Find your cacher snippets",
       "default_value": "cc"
+    },
+    {
+      "id": "api_key",
+      "type": "input",
+      "name": "API Key",
+      "description": "Located under Applications menu on your Cacher home page"
+    },
+    {
+      "id": "api_token",
+      "type": "input",
+      "name": "API Token",
+      "description": "Located under Applications menu on your Cacher home page"
     }
   ]
 }


### PR DESCRIPTION
As we previously discussed, I implemented the feature. 
It took me some time to figure out, but in order to get the configuration we must subscribe to its event first. 
<strike>Also, there's an update listener that allows us to update the configuration during runtime, but it [has a bug](https://github.com/Ulauncher/Ulauncher/issues/239), so for the time being user must restart Ulauncher (or save the settings twice) after initially filling in the credentials.</strike>
Update: Bug has been fixed ;)

I also updated README to reflect those changes.