### PR TITLE
Added support to new Ulauncher API and Python 3

### DIFF
--- a/CacherExtension.py
+++ b/CacherExtension.py
@@ -133,8 +133,9 @@ class Cacher(Extension):
         for i in range(0, self.matches_len):
             labels = self.get_labels(labels_data, matches[i]['guid'])
             items.append(ExtensionResultItem(icon='images/cacher.png',
-                                             name='%s' % matches[i]['title'],
-                                             description='%s' % matches[i]['file'] + ' ' + ''.join(labels),
-                                             on_enter=CopyToClipboardAction(matches[i]['data'])))
+                                             name='%s' % matches[i]['title'].decode("utf-8"),
+                                             description='%s' % matches[i]['file'].decode(
+                                                 "utf-8") + ' ' + ''.join(labels),
+                                             on_enter=CopyToClipboardAction(matches[i]['data'].decode('utf-8'))))
 
         return items

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-  "manifest_version": "2",
-  "api_version": "1",
+  "required_api_version": "^2.0.0",
   "name": "Cacher",
   "description": "Search in cacher snippets",
   "developer_name": "Dmitry Antonenko",

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,10 @@
+[
+    {
+        "required_api_version": "^1.0.0",
+        "commit": "python2"
+    },
+    {
+        "required_api_version": "^2.0.0",
+        "commit": "master"
+    }
+]


### PR DESCRIPTION
This PR adds support to the new Ulauncher API and Python 3.

The "decode" function needs to be used before printing any value because from what I understood, in Python 3 string are represented as a byte string, resulting in a  "b" character appearing in the start of all the suggestions.

Not sure if is the best way to do it as I am not Python expert, but seems to work fine.

More about this:

* [Strings, Bytes, and Unicode in Python 2 and 3 - Timothy Bramlett](https://timothybramlett.com/Strings_Bytes_and_Unicode_in_Python_2_and_3.html)
* [python - What does the 'b' character do in front of a string literal? - Stack Overflow](https://stackoverflow.com/questions/6269765/what-does-the-b-character-do-in-front-of-a-string-literal)

Also, to keep this extension working with the Python 2, please create a branch called "python2" before merging this PR. You can use the name you want but need to change on the versions.json file.